### PR TITLE
Add `dynamic` entry to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+dynamic = ["license", "dependencies"]
 
 [project.urls]
 "Homepage" = "https://github.com/wwwjk366/gower"


### PR DESCRIPTION
While trying to package gower for NixOS (https://github.com/NixOS/nixpkgs/pull/350747), we realized that there is a missing field in the pyproject.toml that makes building the package not possible unless we delete the pyproject.toml file, which is not ideal.

This patch fixes this issue.